### PR TITLE
Now can build new subtrees of the parent after any node runs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "https://github.com/hexbatch/hbc-things/issues"
     },
     "license": "Apache-2.0",
-    "version": "1.0",
+    "version": "1.1",
 
     "require": {
         "ext-pdo": "*",

--- a/releases.md
+++ b/releases.md
@@ -1,2 +1,8 @@
-# version 0.1.0  Feb 14, 2025
+# version 1.1.0  Feb 14, 2025
+* Now can build new subtrees of the parent when a node finishes running
+
+# version 1.0.0  May 16, 2025
+* First working code
+
+* # version 0.1.0  Feb 14, 2025
 * First code

--- a/src/Interfaces/IThingAction.php
+++ b/src/Interfaces/IThingAction.php
@@ -17,7 +17,10 @@ interface IThingAction
     public function getActionPriority() : int;
     public function getActionType() : string;
     public static function getActionTypeStatic() : string;
-    public function getChildrenTree(?string $key = null) : ?Tree;
+    public function getChildrenTree() : ?Tree;
+
+    /** @return IThingAction[] */
+    public function getMoreSiblingActions() : array;
 
     public function runAction(array $data = []): void;
 


### PR DESCRIPTION
version (1.1.0)

Determined by new method in action contract. Independent of the action return type or thing status later

Removed unused param in another action method