### PR TITLE
Version 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hexbatch Things, version 1.0
+# Hexbatch Things
 
 Creates tree structures to run actions from the leaves up. The code for the actions and owners is made by the project which uses this.
 When each action runs, optional hooks can be set before, after or for completion or error, these hooks can call http, code or fire events.
@@ -7,6 +7,16 @@ This is a laravel package that employes job queues and batches to run each task,
 
 
 ## Releases
+
+# version 1.2.1 May 28
+* Action wait timeout now set
+* Thing response can be used as a code callback
+* Fixup some issues with waiting and saving status
+* Add migration to help with database resets; renamed cron job
+* Simplified leaf gathering
+* More settable properties from children trees
+* Errors now have related tags
+* Many bug fixes
 
 # version 1.2.0  May 25, 2025
 * Owner and action ids are now displayed as their uuid and not the numberic id.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "https://github.com/hexbatch/hbc-things/issues"
     },
     "license": "Apache-2.0",
-    "version": "1.2.0",
+    "version": "1.2.1",
 
     "require": {
         "ext-pdo": "*",

--- a/database/migrations/2013_05_26_075822_drop_all_thing_enums.php
+++ b/database/migrations/2013_05_26_075822_drop_all_thing_enums.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement("DROP FUNCTION IF EXISTS update_modified_column();");
+
+        DB::statement("DROP TYPE IF EXISTS type_of_thing_status;");
+        DB::statement("DROP TYPE IF EXISTS type_of_thing_hook_mode;");
+        DB::statement("DROP TYPE IF EXISTS type_of_thing_callback;");
+        DB::statement("DROP TYPE IF EXISTS type_of_thing_callback_status;");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //does nothing going down
+    }
+};

--- a/database/migrations/2024_09_24_213249_create_thing_errors.php
+++ b/database/migrations/2024_09_24_213249_create_thing_errors.php
@@ -27,8 +27,15 @@ return new class extends Migration
                 ->nullable(false)
                 ->comment("used for display and id outside the code");
 
+
+
+
             $table->text('thing_error_file')->default(null)->nullable()
                 ->comment('The file of the exception');
+
+            $table->jsonb('related_tags')
+                ->nullable()->default(null)
+                ->comment("array of string tags from the thing or hook");
 
             $table->text('thing_error_message')->default(null)->nullable()
                 ->comment('the message');

--- a/database/migrations/2024_09_26_220530_create_things.php
+++ b/database/migrations/2024_09_26_220530_create_things.php
@@ -42,7 +42,7 @@ return new class extends Migration
                 ->index()
                 ->constrained('thing_errors')
                 ->cascadeOnUpdate()
-                ->cascadeOnDelete();
+                ->nullOnDelete();
 
 
 
@@ -88,9 +88,6 @@ return new class extends Migration
                 ->nullable(false)->default(0)
                 ->comment("if true, then will not complete immediately");
 
-            $table->boolean('is_signalling_when_done')
-                ->nullable(false)->default(0)
-                ->comment("if true, then will try to call the parent when its logic is done");
 
 
             $table->uuid('ref_uuid')

--- a/database/migrations/2024_09_27_111111_create_thing_callbacks.php
+++ b/database/migrations/2024_09_27_111111_create_thing_callbacks.php
@@ -62,10 +62,6 @@ return new class extends Migration
 
 
 
-            $table->boolean('is_signalling_when_done')
-                ->nullable(false)->default(0)
-                ->comment("if true, then will try to call the parent when its logic is done");
-
             $table->integer('callback_http_code')->nullable()->default(null)
                 ->comment('When the callback was made, what was the http code from that url');
 

--- a/database/migrations/2025_05_25_180543_version_1.2.0_changes.php
+++ b/database/migrations/2025_05_25_180543_version_1.2.0_changes.php
@@ -69,36 +69,11 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('things', function (Blueprint $table) {
-            $table->string('action_type',30)
-                ->nullable()->default(null)
-                ->comment("The type of action")
-                ->change();
-
-            $table->string('owner_type',30)
-                ->nullable()->default(null)
-                ->comment("The type of owner")
-                ->change();
 
             $table->dropColumn('thing_wait_until_at');
         });
 
-
-        Schema::table('thing_hooks', function (Blueprint $table) {
-            $table->string('action_type',30)
-                ->nullable()->default(null)
-                ->comment("Hooks can filter on a specific action")
-                ->change();
-
-            $table->string('owner_type',30)
-                ->nullable()->default(null)
-                ->comment("The type of owner")
-                ->change();
-
-            $table->string('filter_owner_type',30)
-                ->nullable()->default(null)
-                ->comment("Hooks can filter on an owner type")
-                ->change();
-        });
+        //don't change the column size back, it will not work unless no data or the names are short
 
         Schema::table('thing_callbacks', function (Blueprint $table) {
             $table->dropColumn('wait_in_seconds');

--- a/src/Commands/WakeThings.php
+++ b/src/Commands/WakeThings.php
@@ -14,7 +14,7 @@ class WakeThings extends Command
      *
      * @var string
      */
-    protected $signature = 'hex-thing:wake';
+    protected $signature = 'hex:wake_things';
 
     /**
      * The console command description.

--- a/src/Enums/TypeOfThingStatus.php
+++ b/src/Enums/TypeOfThingStatus.php
@@ -35,6 +35,10 @@ enum TypeOfThingStatus : string {
         self::THING_FAIL,
     ];
 
+    const array INCOMPLETE_STATUSES = [
+        self::THING_BUILDING,self::THING_PENDING,self::THING_WAITING,self::THING_RUNNING
+    ];
+
 
 }
 

--- a/src/Interfaces/IHookCode.php
+++ b/src/Interfaces/IHookCode.php
@@ -2,7 +2,12 @@
 
 namespace Hexbatch\Things\Interfaces;
 
+use Hexbatch\Things\Models\Thing;
+use Hexbatch\Things\Models\ThingCallback;
+use Hexbatch\Things\Models\ThingHook;
+
 interface IHookCode
 {
-    public static function runHook(array $header,array $body) : ICallResponse;
+    public static function runHook(ThingCallback $callback,Thing $thing,ThingHook $hook,array $header,array $body)
+    : ICallResponse;
 }

--- a/src/Interfaces/IThingAction.php
+++ b/src/Interfaces/IThingAction.php
@@ -15,7 +15,7 @@ interface IThingAction
     public function isActionError() : bool;
 
     public function getActionId() : int;
-    public function getActionUuid() : string;
+    public function getActionUuid() : ?string;
     public function getActionRef() : ?string;
     public function getActionPriority() : int;
     public function getActionType() : string;

--- a/src/Jobs/RunThing.php
+++ b/src/Jobs/RunThing.php
@@ -39,7 +39,7 @@ class RunThing implements ShouldQueue
     {
         try {
             $this->thing->runThing();
-            if ($this->thing->thing_status === TypeOfThingStatus::THING_ERROR) {
+            if (!$this->thing->isComplete()) {
                 $this->fail();
             }
         } catch (\Exception $e) {

--- a/src/Jobs/RunThing.php
+++ b/src/Jobs/RunThing.php
@@ -3,7 +3,6 @@ namespace Hexbatch\Things\Jobs;
 
 
 
-use Hexbatch\Things\Enums\TypeOfThingStatus;
 use Hexbatch\Things\Models\Thing;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
@@ -44,11 +43,6 @@ class RunThing implements ShouldQueue
             }
         } catch (\Exception $e) {
             Log::error(message: "while running thing: ".$e->getMessage(),context: ['thing_id'=>$this->thing?->id??null,'file'=>$e->getFile(),'line'=>$e->getLine(),'code'=>$e->getCode()]);
-            try {
-                $this->thing->setException($e) ;
-            } catch (\Exception $f) {
-                Log::error(message: "while in error state and saving : ".$f->getMessage(),context: ['thing_id'=>$this->thing?->id??null,'file'=>$f->getFile(),'line'=>$f->getLine(),'code'=>$f->getCode()]);
-            }
             $this->fail($e);
         }
     }

--- a/src/Models/Thing.php
+++ b/src/Models/Thing.php
@@ -347,7 +347,7 @@ class Thing extends Model
             }
 
             if (in_array($status,TypeOfThingStatus::STATUSES_OF_COMPLETION)) {
-                $this->setRunData(status: $status);
+                $this->setRunData(status: $status,wait_seconds: $action->getWaitTimeout());
                 if ($this->is_signalling_when_done) {
                     //it is done, for better or worse
                     $this->signal_parent();

--- a/src/Models/Thing.php
+++ b/src/Models/Thing.php
@@ -441,7 +441,9 @@ class Thing extends Model
     public function getCallbacksOfType(TypeOfHookMode $which,?bool $blocking = null,?bool $after = null,&$unresolved_manual = []) : array {
 
         /** @var ThingHook[] $hooks */
-        $hooks = ThingHook::buildHook( mode:$which,action: $this->getAction(), hook_owner_group: $this->getOwner(),
+        $hooks = ThingHook::buildHook( mode:$which,
+            action_type: $this->getAction()?->getActionType(), maybe_action_id: $this->getAction()?->getActionId(),
+            hook_owner_group: $this->getOwner(),
             hook_group_hint: TypeOfOwnerGroup::HOOK_CALLBACK_CREATION,
             tags: $this->thing_tags->getArrayCopy(),is_on: true,is_after: $after,is_blocking: $blocking)->get();
 
@@ -757,7 +759,10 @@ class Thing extends Model
         $the_action = $node->action;
 
         $children = $node->getChildren();
-
+        if (count($children) === 0) {
+            $use_this_tree = $the_action->getChildrenTree();
+            $children = $use_this_tree?->getRootNodes()??[];
+        }
         $tree_node = static::makeThingFromAction(parent_thing: $parent_thing,action: $the_action);
 
         foreach ( $children as $child) {

--- a/src/Models/ThingCallback.php
+++ b/src/Models/ThingCallback.php
@@ -43,7 +43,6 @@ use TorMorten\Eventy\Facades\Eventy;
  *
  *
  * @property int callback_http_code
- * @property bool is_signalling_when_done
  * @property bool is_halting_thing_stack
  *
  * @property string ref_uuid
@@ -81,7 +80,6 @@ class ThingCallback extends Model
      * @var array<int, string>
      */
     protected $fillable = [
-        'is_signalling_when_done'
     ];
 
     /**
@@ -97,7 +95,6 @@ class ThingCallback extends Model
      * @var array<string, string>
      */
     protected $casts = [
-        'is_signalling_when_done' => 'boolean',
         'is_halting_thing_stack' => 'boolean',
         'callback_outgoing_data' => AsArrayObject::class,
         'callback_incoming_data' => AsArrayObject::class,
@@ -367,7 +364,7 @@ class ThingCallback extends Model
                 'callback' => $this->ref_uuid,
                 'hook' => $hook->ref_uuid,
                 'thing' => $thing->ref_uuid,
-                'action' => $action?->getActionRef()??null,
+                'action' => $action?->getActionUuid()??null,
                 'status' => $thing?->thing_status
             ]
 
@@ -459,26 +456,8 @@ class ThingCallback extends Model
         if (!$thing) {$thing = $this->thing_source;}
 
         $found_data = $this->getOutgoingDataAsArray(hook: $hook,thing: $thing);
-
-        if (empty($found_data)) {
-            $prep = $found_data;
-        } else {
-            $prep = [];
-            foreach ($source as $key => $value) {
-                if ($value === null && isset($found_data[$key])) {
-                    $prep[$key] = $found_data[$key];
-                } else {
-                    $prep[$key] = $value;
-                }
-            }
-        }
-
-        foreach ($prep as $p_key => $p_val) {
-            if ($p_val === null) { unset($prep[$p_key]);}
-        }
-
-
-        return $prep;
+        return $found_data;
+        //todo figure out better templating
     }
 
 
@@ -684,10 +663,6 @@ class ThingCallback extends Model
                     }
                 }
 
-
-                if ($this->is_signalling_when_done) {
-                    $this->thing_source->pushLeavesToJobs();
-                }
             }
 
         } catch (Exception $e) {
@@ -799,9 +774,6 @@ class ThingCallback extends Model
         }
     }
 
-    public function setSignalWhenDone() {
-        $this->update(['is_signalling_when_done'=>true]);
-    }
 
 
 }

--- a/src/Models/ThingHook.php
+++ b/src/Models/ThingHook.php
@@ -270,7 +270,7 @@ class ThingHook extends Model
         elseif ( $hook_group_hint === TypeOfOwnerGroup::HOOK_LIST) {
 
             $hook_owner_group?->setReadGroupBuilding(builder: $build,connecting_table_name: 'thing_hooks',
-                connecting_owner_type_column: 'owner_type',connecting_owner_id_column: 'owner_type_id',hint: $hook_group_hint);
+                connecting_owner_type_column: 'owner_type',connecting_owner_id_column: 'owner_type_id',hint: $hook_group_hint,alias: 'hook_owner');
 
         }
 

--- a/src/Models/Traits/ThingActionHandler.php
+++ b/src/Models/Traits/ThingActionHandler.php
@@ -9,7 +9,9 @@ trait ThingActionHandler
     /** @var array<string,string|IThingAction> $action_type_lookup  */
     protected static array $action_type_lookup = [];
 
-
+    public static function getLookupHash() : array {
+        return array_keys(static::$action_type_lookup);
+    }
     public function getAction() : ?IThingAction {
         return static::resolveAction(action_type: $this->action_type,action_id: $this->action_type_id);
     }
@@ -24,7 +26,7 @@ trait ThingActionHandler
         } elseif ($uuid) {
             return $resolver::resolveActionFromUiid(uuid: $uuid);
         }
-
+        return null;
     }
 
     protected static function isRegisteredActionType(string $action_type) : bool {

--- a/src/OpenApi/Errors/ThingErrorResponse.php
+++ b/src/OpenApi/Errors/ThingErrorResponse.php
@@ -26,6 +26,10 @@ class ThingErrorResponse  implements  JsonSerializable {
     #[OA\Property( title: 'Time',description: "Iso 8601 datetime string for when error happened", format: 'datetime',example: "2025-01-25T15:00:59-06:00")]
     public ?string $time = null;
 
+    #[OA\Property( title:"Related tags",nullable: true)]
+    /** @var string[] $tags */
+    protected ?array $related_tags;
+
     public function __construct(
         protected ThingError $error
     ) {
@@ -33,6 +37,7 @@ class ThingErrorResponse  implements  JsonSerializable {
         $this->message = $this->error->thing_error_message;
         $this->uuid = $this->error->ref_uuid;
         $this->time = Carbon::parse($this->error->created_at,'UTC')->timezone(config('app.timezone'))->toIso8601String();
+        $this->related_tags = $this->error->related_tags?->getArrayCopy()??[];
     }
     public function jsonSerialize(): array
     {
@@ -41,6 +46,7 @@ class ThingErrorResponse  implements  JsonSerializable {
             'code' => $this->code,
             'uuid' => $this->uuid,
             'time' => $this->time,
+            'tags' => $this->related_tags,
         ];
     }
 }

--- a/src/OpenApi/Hooks/HookParams.php
+++ b/src/OpenApi/Hooks/HookParams.php
@@ -5,7 +5,6 @@ namespace Hexbatch\Things\OpenApi\Hooks;
 
 use Hexbatch\Things\Enums\TypeOfCallback;
 use Hexbatch\Things\Enums\TypeOfHookMode;
-use Hexbatch\Things\Interfaces\IThingAction;
 use Hexbatch\Things\Interfaces\IThingOwner;
 use Hexbatch\Things\Models\ThingHook;
 use Hexbatch\Things\Requests\HookRequest;
@@ -256,9 +255,9 @@ class HookParams implements JsonSerializable
 
     public function getFilterOwnerId(): ?int
     {
-
+        if (!$this->filter_owner_id) {return null;}
         if (Uuid::isValid($this->filter_owner_id)) {
-            if ($this->action_type) {
+            if ($this->filter_owner_type) {
                 $owner = ThingHook::resolveOwner(owner_type: $this->filter_owner_type,owner_uuid: $this->filter_owner_id);
                 if (!$owner) {
                     throw new \LogicException("[getFilterOwnerId] Owner id $this->filter_owner_id for type $this->filter_owner_type was passed in without validation");
@@ -270,14 +269,14 @@ class HookParams implements JsonSerializable
         return $this->filter_owner_id;
     }
 
-    public function getFilterOwnerGuid(): ?int
+    public function getFilterOwnerGuid(): ?string
     {
-
+        if (!$this->filter_owner_id) {return null;}
         if (!Uuid::isValid($this->filter_owner_id)) {
-            if ($this->action_type) {
+            if ($this->filter_owner_type) {
                 $owner = ThingHook::resolveOwner(owner_type: $this->filter_owner_type,owner_id: $this->filter_owner_id);
                 if (!$owner) {
-                    throw new \LogicException("[getFilterOwnerId] Owner id $this->filter_owner_id for type $this->filter_owner_type was passed in without validation");
+                    throw new \LogicException("[getFilterOwnerGuid] Owner id $this->filter_owner_id for type $this->filter_owner_type was passed in without validation");
                 }
                 return $owner->getOwnerUuid();
             }
@@ -300,6 +299,7 @@ class HookParams implements JsonSerializable
 
     public function getActionId(): ?int
     {
+        if (!$this->action_id) {return null;}
         if (Uuid::isValid($this->action_id)) {
             if ($this->action_type) {
                 $action = ThingHook::resolveAction(action_type: $this->action_type,uuid: $this->action_id);
@@ -316,6 +316,7 @@ class HookParams implements JsonSerializable
 
     public function getActionGuid(): ?string
     {
+        if (!$this->action_id) {return null;}
         if (!Uuid::isValid($this->action_id)) {
             if ($this->action_type) {
                 $action = ThingHook::resolveAction(action_type: $this->action_type,action_id: $this->action_id);

--- a/src/OpenApi/Hooks/HookResponse.php
+++ b/src/OpenApi/Hooks/HookResponse.php
@@ -78,8 +78,8 @@ class HookResponse extends HookParams implements  JsonSerializable
     {
         $arr = parent::jsonSerialize();
         $arr['uuid'] = $this->uuid;
-        $arr['owner_id'] = $this->owner_id;
-        $arr['owner_type'] = $this->owner_type;
+        $arr['owner_id'] = $this?->owner_id;
+        $arr['owner_type'] = $this?->owner_type;
 
         if ($this->b_include_callbacks) {
             $arr['callbacks'] = $this->callbacks;

--- a/src/OpenApi/Things/ThingResponse.php
+++ b/src/OpenApi/Things/ThingResponse.php
@@ -52,10 +52,10 @@ class ThingResponse  implements  JsonSerializable,ICallResponse
 
 
     #[OA\Property( title:"Owner name")]
-    protected string $owner_name;
+    protected ?string $owner_name;
 
     #[OA\Property( title:"Owner ref")]
-    protected string $owner_ref;
+    protected ?string $owner_ref;
 
     #[OA\Property( title:"Async")]
     protected bool $async;
@@ -106,8 +106,8 @@ class ThingResponse  implements  JsonSerializable,ICallResponse
         $this->tags = $this->thing->thing_tags?->getArrayCopy()??[];
 
         $owner = $thing->getOwner();
-        $this->owner_name = $owner->getName();
-        $this->owner_ref = $owner->getOwnerUuid();
+        $this->owner_name = $owner?->getName();
+        $this->owner_ref = $owner?->getOwnerUuid();
 
         if($this->thing->thing_started_at) {
             $this->started_at = Carbon::parse($this->thing->thing_started_at,'UTC')->timezone(config('app.timezone'))->toIso8601String();
@@ -152,8 +152,8 @@ class ThingResponse  implements  JsonSerializable,ICallResponse
         $arr['action_name'] = $this->action_name;
         $arr['action_ref'] = $this->action_ref;
 
-        $arr['owner_name'] = $this->action_name;
-        $arr['owner_ref'] = $this->action_ref;
+        $arr['owner_name'] = $this->owner_name;
+        $arr['owner_ref'] = $this->owner_ref;
         $arr['action_info'] = $this->action_info;
         $arr['action_html'] = $this->action_html;
         $arr['tags'] = array_values($this->tags);


### PR DESCRIPTION
# version 1.2.1 May 28
* Action wait timeout now set
* Thing response can be used as a code callback
* Fixup some issues with waiting and saving status
* Add migration to help with database resets; renamed cron job
* Simplified leaf gathering
* More settable properties from children trees
* Errors now have related tags
* Many bug fixes